### PR TITLE
fix: sort object keys when displaying JSON, rather than when fetching it

### DIFF
--- a/webapp/js/components/utils/JSONEditor.js
+++ b/webapp/js/components/utils/JSONEditor.js
@@ -5,6 +5,7 @@ import * as dialogTypes from 'constants/dialogTypes';
 import {jsonEditorChangeMode} from 'actions/jsonEditorActions';
 import {openDialog} from 'actions/dialogActions';
 import '../../../style/vendor/jsoneditor.css';
+import { sortObjectKeys } from '../../utils/utils';
 
 export class JSONEditor extends Component {
 
@@ -37,8 +38,12 @@ export class JSONEditor extends Component {
         }
     }
 
+    updateValue(value) {
+        this.editor.set(sortObjectKeys(value))
+    }
+
     componentWillUpdate(nextProps) {
-        this.editor.set(nextProps.value);
+        this.updateValue(nextProps.value);
         this.handleJsonEditor(nextProps);
     }
 
@@ -119,7 +124,7 @@ export class JSONEditor extends Component {
             };
             this.editor = new JSEditor(this.editorContainer, opts);
             this.removeBuiltInMenu();
-            this.editor.set(this.props.value);
+            this.updateValue(this.props.value);
         }
     }
 

--- a/webapp/js/constants/apiUrls.js
+++ b/webapp/js/constants/apiUrls.js
@@ -1,1 +1,1 @@
-export const API_URL = 'https://play.dhis2.org/test/api';
+export const API_URL = 'https://debug.dhis2.org/dev/api';

--- a/webapp/js/utils/api.js
+++ b/webapp/js/utils/api.js
@@ -70,7 +70,7 @@ class Api
             return this.getMetaData(namespace, key)
                 .then(result => {
                     const jsonLength = result.value.length;
-                    const val = sortObjectKeys(JSON.parse(result.value));
+                    const val = JSON.parse(result.value);
 
                     // cache result
                     if (cache[namespace] === undefined) {
@@ -242,19 +242,3 @@ class Api
 
 export default (() =>
     new Api(API_URL).initialize())();
-
-
-const sortObjectKeys = obj => {
-    if (!obj || typeof obj !== 'object') {
-        return obj
-    }
-    if (Array.isArray(obj)) {
-        return obj.map(sortObjectKeys)
-    }
-    return Object.keys(obj)
-        .sort()
-        .reduce((res, key) => {
-            res[key] = sortObjectKeys(obj[key])
-            return res
-        }, {})
-}   

--- a/webapp/js/utils/utils.js
+++ b/webapp/js/utils/utils.js
@@ -13,3 +13,18 @@ export function debounce(func, wait, immediate) {
         if (callNow) func.apply(context, args);
     };
 };
+
+export const sortObjectKeys = obj => {
+    if (!obj || typeof obj !== 'object') {
+        return obj
+    }
+    if (Array.isArray(obj)) {
+        return obj.map(sortObjectKeys)
+    }
+    return Object.keys(obj)
+        .sort()
+        .reduce((res, key) => {
+            res[key] = sortObjectKeys(obj[key])
+            return res
+        }, {})
+}


### PR DESCRIPTION
This is an amendment to https://github.com/dhis2/datastore-app/pull/16 - I've moved the key sorting logic to a util file and perform the sorting when the value is displayed, rather than when it is fetched.  This ensures that values are sorted after editing a particular key.  Note that while still in the editor the keys will not be re-sorted, but once navigating away and back to the key in question it will sort again.